### PR TITLE
Identify unique combinations of taxids before running NCBI topology

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - conda-forge::python-rocksdb >=0.7.0
     - conda-forge::xopen >=0.9.0
     - tqdm >=4.45.0
+    - ordered-set >=4.0.2
     - pandas >=1.1.4
     
 test:

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - click=7.1.2
   - ete3=3.1.2
   - nbsphinx=0.8.1
+  - ordered-set=4.0.2
   - pandas=1.2.1
   - pandoc=2.11.4
   - pip=21.0.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         'xopen',
         'python-rocksdb',
         'ete3',
-        'pandas'
+        'pandas',
+        'ordered_set'
     ],
     packages=find_packages(include=['sam2lca']),
     entry_points={


### PR DESCRIPTION
Reduces the run time of sam2lca by identifying all unique combinations of taxids that were observed across all reads and by running the expensive NCBI topology function of ete3 on these. For samples that have a lot of aligned reads but only a few combinations of taxids, this will decrease the number of lookups strongly.