### PR TITLE
Replace reference management with using ref ids instead of names

### DIFF
--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -1,14 +1,14 @@
 # Tutorial
 
-**Using [sam2lca](https://github.com/maxibor/sam2lca) to identify a plant taxon from a `fastq` sequencing files.**
+**Using [sam2lca](https://github.com/maxibor/sam2lca) to identify plant taxa from `fastq` sequencing files.**
 
-In this tutorial, we'll use the [Angiosperms353](https://academic.oup.com/sysbio/article/68/4/594/5237557) plant markers database, which consists of up to 353 universal Angiosperms (flowering plants) gene markers, derived from the [1000 plant transcriptomes](https://www.nature.com/articles/s41586-019-1693-2) project, to identify a the plant species present in our sequencing data.
+In this tutorial, we'll use the [Angiosperms353](https://academic.oup.com/sysbio/article/68/4/594/5237557) plant markers database, which consists of up to 353 universal Angiosperms (flowering plants) gene markers, derived from the [1000 plant transcriptomes](https://www.nature.com/articles/s41586-019-1693-2) project, to identify the plant species present in our sequencing data.
 
 ## Installing all tools for this tutorial
 
 For this tutorial, a dedicated conda-environment is available to ease the reproducibility.
 
-Download environment
+Downloading environment
 
 ```bash
 $ wget https://raw.githubusercontent.com/maxibor/sam2lca/master/docs/tutorial/environment.yaml
@@ -33,15 +33,17 @@ $ gunzip angiosperms353_markers.fa.gz
 
 ## Indexing the database with Bowtie2
 
-In this tutorial, we're going to work with the [Bowtie2](https://github.com/BenLangmead/bowtie2) read aligner, but other aligners like [BWA](http://bio-bwa.sourceforge.net/) are also just fine.
+In this tutorial, we're going to use [Bowtie2](https://github.com/BenLangmead/bowtie2) to align the sequencing data, but other aligners, such as [BWA](http://bio-bwa.sourceforge.net/), also work just fine.
 
-Before doing any alignment, we need to index the angiosperms353 database with bowtie2
+Before being able to do any alignment, we need to index the angiosperms353 database with bowtie2
 
 ```bash
 $ bowtie2-build angiosperms353_markers.fa angiosperms353
 ```
 
 ## Preparing `fastq` sequencing files
+
+Next, we will prepare the sequencing data.
 
 - Downloading the paired-end DNA sequencing compressed `fastq` files
 
@@ -69,7 +71,7 @@ $ samtools index metagenome.sorted.bam
 
 ## Running sam2lca
 
-Once we have our alignment file, here in `bam` format, we can now run [sam2lca](https://github.com/maxibor/sam2lca) to identify which plants shed some of its DNA in our sequencing file.
+Once we have our alignment file, here in `bam` format, we can now run [sam2lca](https://github.com/maxibor/sam2lca) to identify the lowest common ancestor species for the aligned reads and thus infer which plants shed some of its DNA in our sequencing file.
 
 First, we need to set up the sam2lca database for *plant markers*
 

--- a/sam2lca/main.py
+++ b/sam2lca/main.py
@@ -40,7 +40,7 @@ def sam2lca(
             f"\t'{acc2tax_db}' database seems to be missing, I'm creating it for you."
         )
         get_mapping(mappings, dbdir=dbdir, update=False)
-    reads_taxid_dict = compute_lca_multi(read_dict, al.refs, acc2tax_db, tree, process)
+    reads_taxid_dict = compute_lca_multi(read_dict, al.refs, al.refnames, acc2tax_db, tree, process)
     taxid_counts, taxid_reads = utils.count_reads_taxid(reads_taxid_dict)
     utils.taxid_to_lineage(taxid_counts, output["sam2lca"])
     if bam_out:

--- a/sam2lca/main.py
+++ b/sam2lca/main.py
@@ -28,7 +28,7 @@ def sam2lca(
     if not output:
         output = utils.output_file(sam)
     utils.check_extension(sam)
-    logging.info("Step 1/6: Parsing alignment file")
+    logging.info("Step 1/6: Parsing the alignment file")
     al = Alignment(al_file=sam)
     read_dict = al.get_reads(
         process=process, identity=identity, minlength=length, check_conserved=conserved

--- a/sam2lca/sam_ete.py
+++ b/sam2lca/sam_ete.py
@@ -11,7 +11,7 @@ from ordered_set import OrderedSet
 import logging
 
 
-def accession_to_taxid_lookup(accession_list):
+def accession_to_taxid_lookup(accession_list, refnames):
     """Get TAXID of hits from hit accessions per read
 
     Args:
@@ -20,7 +20,7 @@ def accession_to_taxid_lookup(accession_list):
         dict: {accession: taxid}
     """
     try:
-        return {i: int(DB.get(bytes(i, encoding="utf8"))) for i in tqdm(accession_list)}
+        return {i: int(DB.get(bytes(refnames[i], encoding="utf8"))) for i in tqdm(accession_list)}
     except TypeError as e:
         print(e)
         return None
@@ -70,7 +70,7 @@ def taxids_to_lca(taxids, tree):
     return {taxids: int(ancestor)}
 
 
-def compute_lca_multi(read_dict, accession_list, dbname, tree, process):
+def compute_lca_multi(read_dict, accession_list, refnames, dbname, tree, process):
     global DB
 
     logging.info("Step 2/6: Loading the taxonomy database")
@@ -78,7 +78,7 @@ def compute_lca_multi(read_dict, accession_list, dbname, tree, process):
     DB = rocksdb.DB(dbname, opts=OPTS_read, read_only=True)
     logging.info("* Finished loading the taxonomy database")
     logging.info("Step 3/6: Converting accession numbers to TAXIDs")
-    accession2taxid = accession_to_taxid_lookup(accession_list)
+    accession2taxid = accession_to_taxid_lookup(accession_list, refnames)
     del DB
 
     if tree:

--- a/sam2lca/sam_ete.py
+++ b/sam2lca/sam_ete.py
@@ -73,10 +73,10 @@ def taxids_to_lca(taxids, tree):
 def compute_lca_multi(read_dict, accession_list, dbname, tree, process):
     global DB
 
-    logging.info("Step 2/6: Loading Taxonomy database")
+    logging.info("Step 2/6: Loading the taxonomy database")
 
     DB = rocksdb.DB(dbname, opts=OPTS_read, read_only=True)
-    logging.info("* Finished loading Taxonomy database")
+    logging.info("* Finished loading the taxonomy database")
     logging.info("Step 3/6: Converting accession numbers to TAXIDs")
     accession2taxid = accession_to_taxid_lookup(accession_list)
     del DB


### PR DESCRIPTION
Instead of using reference names for keeping track to which accessions the reads aligned, too, the algorithm stores uses instead the numerical index of the reference names, i.e. the reference_id. While it adds some additional lookups of the reference name in the method `__get_reads_single__`, it allows us to obtain a sorted set of integer values instead of strings for the method `read_accession_to_taxid`, which should decrease the time per read.