### PR TITLE
Add option for greengenes-style lineages

### DIFF
--- a/sam2lca/cli.py
+++ b/sam2lca/cli.py
@@ -146,6 +146,14 @@ def cli(ctx, dbdir):
     show_default=True,
     help="Minimum numbers of reads to write BAM split by TAXID. To use in combination with -b/--bam_out",
 )
+@click.option(
+    "-G",
+    "--greengenes-lineage",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Report lineages as greengenes-style strings (k_Bacteria;p_Pseudomonadota;...) rather than JSON lineage dicts.",
+)
 def analyze(ctx, no_args_is_help=True, **kwargs):
     """\b
     Run the sam2lca analysis

--- a/sam2lca/main.py
+++ b/sam2lca/main.py
@@ -28,6 +28,7 @@ def sam2lca(
     bam_out=False,
     bam_split_rank=False,
     bam_split_read=50,
+    greengenes_lineage=False,
 ):
     """Performs LCA on SAM/BAM/CRAM alignment file
 
@@ -94,6 +95,7 @@ def sam2lca(
         process=process,
         nb_steps=nb_steps,
         taxo_db=TAXDB,
+        greengenes=greengenes_lineage,
     )
 
 


### PR DESCRIPTION
Adds a CLI option to report greengenes-style linages (`k__Bacteria;p__Proteobacteria;...`) in place of the JSON-eque lineages in the current output.

